### PR TITLE
Add cicd/sam dir (with AWS SAM deployment hint) to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,8 @@ To build Amazon Linux 2 compatible binary, see [Deploy.md](./Deploy.md) for more
   - ANY method on route `/{proxy+}` and attach Lambda proxy integration.
 - In settings tab, add `*/*` binary media type.
 - Then, deploy API to stage.
+
+
+## Lambda & API Gateway with AWS SAM
+
+See `examples/cicd/sam/README.md` for AWS SAM deployment hints.

--- a/examples/cicd/sam/Makefile
+++ b/examples/cicd/sam/Makefile
@@ -1,0 +1,38 @@
+.PHONY: build
+
+ARCH = x86_64-unknown-linux-musl
+BIN_NAME = bootstrap
+SAM_TEMPLATE = template.yaml
+STACK_NAME = microservice-actix-sam
+AWS_REGION = us-east-1
+
+build:
+	cargo +nightly build --release --target $(ARCH)
+
+package:
+	rm -rf build && mkdir -p build
+	cp -v ./target/$(ARCH)/release/$(BIN_NAME) build/bootstrap
+
+ci-package: package
+	mkdir interim-wrapper
+	cp -v ./$(SAM_TEMPLATE) ./interim-wrapper/template.yaml
+	cp -v ./Makefile ./interim-wrapper/Makefile
+	mv build interim-wrapper
+	mv interim-wrapper build
+
+deploy:
+	sam validate
+	sam deploy \
+	--stack-name $(STACK_NAME) \
+	--region $(AWS_REGION) \
+	--resolve-s3 \
+	--capabilities CAPABILITY_IAM \
+	--no-confirm-changeset \
+	--no-fail-on-empty-changeset \
+	--force-upload
+
+destroy:
+	sam delete \
+	--stack-name $(STACK_NAME) \
+	--region $(AWS_REGION) \
+	--no-prompts

--- a/examples/cicd/sam/README.md
+++ b/examples/cicd/sam/README.md
@@ -1,0 +1,48 @@
+## Actix Web on Lambda & API Gateway with SAM
+
+Deploy your application with [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html), using [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html). Have a look at a sample role you will want to create and assign to your user.
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "NotAction": [
+                "iam:*",
+                "organizations:*",
+                "account:*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:ListRoles",
+                "iam:ListPolicies",
+                "organizations:DescribeOrganization",
+                "account:ListRegions"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "iam:*",
+            "Resource": "arn:aws:iam::37********43:role/microservice-*-MicroServiceLambdaRole*"
+        }
+    ]
+}
+```
+Its core has been taken from AWS-managed PowerUser. We are just assigning some additional IAM perms wih regard to concrete lambda resource.
+In case you are operating on a limited scope of resource, you will want to cap those permissions, adhering to the principle of least privilege.
+
+Put Makefile (see `./Makefile`) into your project's root - at the same level where your SAM template (see `./template.yaml`) is located and hit:
+```
+make build
+make package
+make deploy
+```
+You can use - as an option - GitHub Actions to automate the deployment. Add the builda and deploy jobs to your project's `.github/workflows` directory (see `./sam-deploy.yaml` sample jobs configuration).
+
+Do not forget to clean up with `make destroy` to avoid unwanted costs. Alternatively, you can delete the stack via AWS Console (CloudFormation service).

--- a/examples/cicd/sam/sam-deploy.yaml
+++ b/examples/cicd/sam/sam-deploy.yaml
@@ -1,0 +1,68 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+env:
+  AWS_REGION: 'us-east-1'
+  SAM_PATH: '/usr/local/bin/sam'
+  ARTIFACTS_NAME: packaged-app
+  ARTIFACTS_PATH: build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      RUST_CHANNEL: nightly
+      TARGET_ARCH: x86_64-unknown-linux-musl
+    steps:
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y musl-tools
+      - uses: actions/checkout@v3
+      - run: rustup toolchain install ${{ env.RUST_CHANNEL }} --target ${{ env.TARGET_ARCH }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            target/${{ env.TARGET_ARCH }}
+          key: ${{ env.TARGET_ARCH }}-compiled-deps-for-lockfile-hash-${{ hashFiles('**/Cargo.lock') }}
+      - run: make build
+      - run: make ci-package
+      # https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACTS_NAME }}
+          path: ${{ env.ARTIFACTS_PATH }}
+
+  deploy:
+    needs: 
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v3
+        id: cache-sam-bin
+        with:
+          path: ${{ env.SAM_PATH }}
+          key: sam-bin
+      - if: ${{ steps.cache-sam-bin.outputs.cache-hit != 'true' }}
+        run: |
+          curl -LO https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip
+          sha256sum aws-sam-cli-linux-x86_64.zip
+          unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
+          sudo ./sam-installation/install --update
+          which sam
+          sam --version
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACTS_NAME }}
+      - run: make deploy

--- a/examples/cicd/sam/template.yaml
+++ b/examples/cicd/sam/template.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Sample SAM Template for Mirco-Service on Lambda
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Api:
+    BinaryMediaTypes:
+      - application~1zip
+  Function:
+    Timeout: 29 # API GW Timeout is 30 seconds
+    Environment:
+      Variables:
+        ENVIRONMENT: PRODUCTION
+    Layers: []
+
+Resources:
+
+  MicroServiceLambda:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      Runtime: provided.al2
+      Architectures:
+        - x86_64
+      CodeUri: build
+      Handler: bootstrap.is.the.handler
+      Events:
+        Root:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Method: ANY
+            Path: /
+        NonRoot:
+          Type: Api
+          Properties:
+            Method: ANY
+            Path: /{proxy+}
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  MicroServiceApiGatewayEndpoint:
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+  MicroServiceLambdaSelfArn:
+    Value: !GetAtt MicroServiceLambda.Arn
+  MicroServiceLambdaIamRoleArn:
+    Value: !GetAtt MicroServiceLambdaRole.Arn


### PR DESCRIPTION
Adding cicd directory to examples. This dir could hold a collection of possible deployments, CICD instructions.
Adding sam deployment hint to cicd directory.